### PR TITLE
Precise return for return_after, even if there are no tasks scheduled…

### DIFF
--- a/src/ischedule/ischedule.py
+++ b/src/ischedule/ischedule.py
@@ -105,7 +105,13 @@ def run_loop(
 
     while not stop_event.is_set() and not monotonic() - start_time > return_after:
         run_pending()
-        next_call_time = min([t.next_call() for t in _tasks]) - monotonic()
-        next_call_time = min(next_call_time, start_time + return_after)
+
+        next_call_time_list = [t.next_call() for t in _tasks]
+        if len(next_call_time_list):
+            next_call_time = min([t.next_call() for t in _tasks]) - monotonic()
+        else:
+            next_call_time = float('inf')
+        elapsed_time = monotonic()-start_time
+        next_call_time = min(next_call_time, elapsed_time - return_after)
         if next_call_time > 0:
             stop_event.wait(next_call_time)

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -1,0 +1,18 @@
+from time import monotonic
+from src.ischedule import run_loop, schedule, reset
+
+def test_cancel_notasks():
+    reset()
+    run_loop(return_after=1)
+
+
+def test_cancel_longtast():
+    reset()
+    @schedule(interval=2)
+    def task():
+        print("Doing task")
+    start = monotonic()
+    run_loop(return_after=1.5)
+    end = monotonic()
+    print(end-start)
+    assert end-start <= 1.5 + 0.001


### PR DESCRIPTION
… or if the scheduled tasks have a long intervals